### PR TITLE
Deflake integration tests

### DIFF
--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -1,6 +1,9 @@
 import { Options } from "selenium-webdriver/chrome.js";
 import { suite } from "selenium-webdriver/testing/index.js";
+import { Builder } from "selenium-webdriver/index.js";
 import { Browser, By, Key } from "selenium-webdriver";
+// import { Builder } from "selenium-webdriver/chromium.js";
+// import {ServiceBuilder} from "selenium-webdriver/chrome.js";
 import { expect } from "chai";
 import * as fs from "fs";
 
@@ -19,104 +22,103 @@ const RUN_IN_HEADLESS_MODE = true;
     More information here: https://www.selenium.dev/documentation/webdriver/waits/
 */
 
-suite(
-  function (env) {
-    let driver;
+describe("Video experience enhancer", function () {
+  let driver;
 
-    beforeEach(async function () {
-      const options = new Options();
-      options.addArguments(`load-extension=${EXTENSION_PATH}`);
-      if (RUN_IN_HEADLESS_MODE) {
-        options.addArguments("headless=new");
-      }
+  beforeEach(async function () {
+    const options = new Options();
+    options.addArguments(`load-extension=${EXTENSION_PATH}`);
+    if (RUN_IN_HEADLESS_MODE) {
+      options.addArguments("headless=new");
+    }
 
-      driver = await env.builder().setChromeOptions(options).build();
-    });
+    console.log("Starting the browser.");
+    driver = await new Builder()
+      .forBrowser("chrome")
+      .setChromeOptions(options)
+      .build();
+  });
 
-    it("popup renders correctly", async function () {
-      await driver.get(`chrome-extension://${EXTENSION_ID}/popup.html`);
-      const headerText = await driver.findElement(By.tagName("h1")).getText();
-      console.log(headerText);
-      expect(headerText).to.equal(
-        "Welcome to video experience enhancer"
-      );
-    });
+  it("popup renders correctly", async function () {
+    await driver.get(`chrome-extension://${EXTENSION_ID}/popup.html`);
+    const headerText = await driver.findElement(By.css("h1")).getText();
+    console.log(headerText);
+    expect(headerText).to.equal("Welcome to video experience enhancer");
+  });
 
-    it("video controls works correctly on coursera", async function () {
-      console.log("Opening Coursera page with a video.");
-      await driver.get(
-        `https://www.coursera.org/lecture/generative-ai-for-everyone/welcome-chD5R`
-      );
+  it("video controls works correctly on coursera", async function () {
+    console.log("Opening Coursera page with a video.");
+    await driver.get(
+      `https://www.coursera.org/lecture/generative-ai-for-everyone/welcome-chD5R`
+    );
 
-      if (!RUN_IN_HEADLESS_MODE) {
-        // Waiting for the cookies bar to load.
-        console.log("Accepting cookies.");
-        await sleep(1 * SECOND);
-        const cookiesButton = await driver
-          .findElement(By.css("#onetrust-accept-btn-handler"))
-          .click();
-      }
-
-      console.log("Loading and playing the video.");
-      await driver
-        .findElement(
-          By.css('button[data-track-component="click_play_video_button"]')
-        )
+    if (!RUN_IN_HEADLESS_MODE) {
+      console.log("Accepting cookies.");
+      // Waiting for the cookies bar to load.
+      await sleep(1 * SECOND);
+      const cookiesButton = await driver
+        .findElement(By.css("#onetrust-accept-btn-handler"))
         .click();
+    }
 
-      console.log("Entering fullscreen mode.");
-      const fullscreenButton = await driver
-        .findElement(By.css('button[title="Fullscreen"]'))
-        .click();
+    console.log("Loading and playing the video.");
+    await driver
+      .findElement(
+        By.css('button[data-track-component="click_play_video_button"]')
+      )
+      .click();
 
-      console.log("Testing that the video is playing.");
-      const video = await driver.findElement(By.css("video"));
-      let currentTime = Number(await video.getAttribute("currentTime"));
-      await sleep(0.1 * SECOND);
-      let newCurrentTime = Number(await video.getAttribute("currentTime"));
-      expect(newCurrentTime).to.be.greaterThan(currentTime);
+    console.log("Entering fullscreen mode.");
+    const fullscreenButton = await driver
+      .findElement(By.css('button[title="Fullscreen"]'))
+      .click();
 
-      console.log("Pausing the video.");
-      await driver.actions().sendKeys(" ").perform();
+    console.log("Testing that the video is playing.");
+    const video = await driver.findElement(By.css("video"));
+    let currentTime = Number(await video.getAttribute("currentTime"));
+    await sleep(0.1 * SECOND);
+    let newCurrentTime = Number(await video.getAttribute("currentTime"));
+    expect(newCurrentTime).to.be.greaterThan(currentTime);
 
-      console.log("Testing that the video is paused.");
-      currentTime = Number(await video.getAttribute("currentTime"));
-      await sleep(0.1 * SECOND);
-      newCurrentTime = Number(await video.getAttribute("currentTime"));
-      expect(currentTime).to.equal(newCurrentTime);
+    console.log("Pausing the video.");
+    await driver.actions().sendKeys(" ").perform();
 
-      console.log("Seeking forward.");
-      await driver.actions().sendKeys(Key.ARROW_RIGHT).perform();
+    console.log("Testing that the video is paused.");
+    currentTime = Number(await video.getAttribute("currentTime"));
+    await sleep(0.1 * SECOND);
+    newCurrentTime = Number(await video.getAttribute("currentTime"));
+    expect(currentTime).to.equal(newCurrentTime);
 
-      console.log("Testing that the video is seeked forward.");
-      newCurrentTime = Number(await video.getAttribute("currentTime"));
-      expect(newCurrentTime).to.be.closeTo(currentTime + 5, 5);
-      currentTime = newCurrentTime;
+    console.log("Seeking forward.");
+    await driver.actions().sendKeys(Key.ARROW_RIGHT).perform();
 
-      console.log("Seeking backward.");
-      await driver.actions().sendKeys(Key.ARROW_LEFT).perform();
+    console.log("Testing that the video is seeked forward.");
+    newCurrentTime = Number(await video.getAttribute("currentTime"));
+    expect(newCurrentTime).to.be.closeTo(currentTime + 5, 5);
+    currentTime = newCurrentTime;
 
-      console.log("Testing that the video is seeked backward.");
-      newCurrentTime = Number(await video.getAttribute("currentTime"));
-      expect(newCurrentTime).to.be.closeTo(currentTime - 5, 5);
-      currentTime = newCurrentTime;
+    console.log("Seeking backward.");
+    await driver.actions().sendKeys(Key.ARROW_LEFT).perform();
 
-      console.log("Playing the video.");
-      await driver.actions().sendKeys(" ").perform();
+    console.log("Testing that the video is seeked backward.");
+    newCurrentTime = Number(await video.getAttribute("currentTime"));
+    expect(newCurrentTime).to.be.closeTo(currentTime - 5, 5);
+    currentTime = newCurrentTime;
 
-      console.log("Testing that the video is playing.");
-      currentTime = Number(await video.getAttribute("currentTime"));
-      await sleep(0.1 * SECOND);
-      newCurrentTime = Number(await video.getAttribute("currentTime"));
-      expect(newCurrentTime).to.be.greaterThan(currentTime);
-    });
+    console.log("Playing the video.");
+    await driver.actions().sendKeys(" ").perform();
 
-    afterEach(async function () {
-      await driver.quit();
-    });
-  },
-  { browsers: [Browser.CHROME] }
-);
+    console.log("Testing that the video is playing.");
+    currentTime = Number(await video.getAttribute("currentTime"));
+    await sleep(0.1 * SECOND);
+    newCurrentTime = Number(await video.getAttribute("currentTime"));
+    expect(newCurrentTime).to.be.greaterThan(currentTime);
+  });
+
+  afterEach(async function () {
+    await driver.quit();
+  });
+});
 
 function sleep(ms) {
   return new Promise((r) => setTimeout(r, ms));

--- a/tests/package.json
+++ b/tests/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Chrome extension that provides additional functionality for video players played in the web",
   "scripts": {
-    "test": "mocha --timeout 10000 integration.test.js"
+    "test": "mocha --timeout 20000 integration.test.js"
   },
   "type": "module",
   "license": "Apache-2.0",


### PR DESCRIPTION
This PR deflake integration tests as they are currently tests are very flaky. 

This PR:
- Avoid using suite as all failures happen before entering beforeEach which indicate issue in testing framework, after this change it began to consistently pass the tests.
- Increases timeout from 10s to 20s to have a bigger safety buffer.