### PR TITLE
Add keyboard shortcut to show/hide English subtitles

### DIFF
--- a/src/coursera.js
+++ b/src/coursera.js
@@ -1,11 +1,43 @@
 // We are adding event listener to the body element as the video element is keep getting out of focus in full screen mode
 document.querySelector("body").addEventListener("keydown", (e) => {
-  // We don't do anything if we are not in fullscreen as it is already working correctly.
-  if (document.fullscreenElement) {
-    video = document.querySelector("video");
-    if (!video) {
-      return;
+  const video = document.querySelector("video");
+  if (!video) {
+    return;
+  }
+
+  // Functionality for both fullscreen and non-fullscreen modes as long as the focused element is the video or an ancestor of the video.
+  if (
+    document.activeElement == video ||
+    document.activeElement.querySelector("video")
+  ) {
+    switch (e.key) {
+      case "c":
+      case "C":
+        const textTracks = video.textTracks;
+        if (!textTracks || textTracks.length === 0) {
+          break;
+        }
+
+        const englishTrack = Array.from(textTracks).find(
+          (e) => e.language === "en"
+        );
+        if (!englishTrack) {
+          break;
+        }
+
+        if (englishTrack.mode === "showing") {
+          englishTrack.mode = "disabled";
+        } else {
+          englishTrack.mode = "showing";
+        }
+
+        e.preventDefault();
+        break;
     }
+  }
+
+  // Functionality for fullscreen mode only (as they are already working in non-fullscreen mode).
+  if (document.fullscreenElement) {
     const inc = 5;
     switch (e.key) {
       case "ArrowRight":

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "Video experience enhancer",
-  "version": "1.0",
+  "version": "1.1.0",
   "description": "This Chrome extension provides additional functionality for video players played in the web.",
   "permissions": ["activeTab"],
   "homepage_url": "https://github.com/walidghallab/video-experience-enhancer",

--- a/src/popup.js
+++ b/src/popup.js
@@ -19,7 +19,7 @@ function isSupportedDomain(url) {
 
 function getInnerHtmlForNotSupportedDomain() {
   return `
-    The extension is not enabled on this website as no issues were reported on it.
+    Functionality on this website already works out of the box.
     ` + getDomForFilingRequest();
 }
 

--- a/src/popup.js
+++ b/src/popup.js
@@ -38,6 +38,9 @@ function getInnerHtmlForSupportedDomain() {
     
         <dt>F or f</dt>
         <dd>Enter/Exit Fullscreen</dd>
+    
+        <dt>C or c</dt>
+        <dd>Show/Hide English subtitles</dd>
     </dl>
     ` + getDomForFilingRequest();
 }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -103,6 +103,16 @@ describe("Video experience enhancer", function () {
 
     console.log("Testing that the video is playing.");
     expect(await video.getProperty("paused")).to.equal(false);
+
+    console.log("Pressing 'c' to show the English subtitles.");
+    await video.click(); // Focus the element.
+    await driver.actions().sendKeys("c").perform();
+
+    console.log("Testing that the English subtitles are shown.");
+    const englishTrack = await video.getProperty("textTracks").then((tracks) =>
+      tracks.find((track) => track.language === "en")
+    );
+    expect(await englishTrack.mode).to.equal("showing");
   });
 
   afterEach(async function () {

--- a/tests/package.json
+++ b/tests/package.json
@@ -1,6 +1,6 @@
 {
   "name": "video-experience-enhancer",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Chrome extension that provides additional functionality for video players played in the web",
   "scripts": {
     "test": "mocha --timeout 20000 integration.test.js"


### PR DESCRIPTION
Add keyboard shortcut to show/hide English subtitles. 

The shortcut is 'c' or 'C' and it works for both fullscreen and non-fullscreen modes.