### PR TITLE
Apply extension keyboard shortcuts on all modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,15 +19,15 @@ Once the extension is installed, you can use it by following these steps:
 
 **Default keyboard shortcuts (can be edited in the extension):**
 
-| Default keyboard shortcut | Functionality                       | Websites              | Notes                                                                                      |
-| ------------------------- | ----------------------------------- | --------------------- | ------------------------------------------------------------------------------------------ |
-| Ctrl + Arrow Up           | Increase video playback rate by 0.5 | All http & https urls | Works in both full-screen mode and non full-screen mode (when foucs is on the video)       |
-| Ctrl + Arrow Down         | Decrease video playback rate by 0.5 | All http & https urls | Works in both full-screen mode and non full-screen mode (when foucs is on the video).      |
-| C or c                    | Show/Hide English subtitles         | coursera.org          | Works in both full-screen mode and non full-screen mode (when foucs is on the video).      |
-| Space                     | Play/Pause video                    | coursera.org          | Works only in full-screen mode as it is already working correctly in non full-screen mode. |
-| Arrow Left                | Seek video backward 5 seconds       | coursera.org          | Works only in full-screen mode as it is already working correctly in non full-screen mode. |
-| Arrow Right               | Seek video forward 5 seconds        | coursera.org          | Works only in full-screen mode as it is already working correctly in non full-screen mode. |
-| F or f                    | Exit full-screen mode               | coursera.org          | Works only in full-screen mode as it is already working correctly in non full-screen mode. |
+| Default keyboard shortcut | Functionality                       | Websites              |
+| ------------------------- | ----------------------------------- | --------------------- |
+| Ctrl + Arrow Up           | Increase video playback rate by 0.5 | All http & https urls |
+| Ctrl + Arrow Down         | Decrease video playback rate by 0.5 | All http & https urls |
+| C or c                    | Show/Hide English subtitles         | coursera.org          |
+| Space                     | Play/Pause video                    | coursera.org          |
+| Arrow Left                | Seek video backward 5 seconds       | coursera.org          |
+| Arrow Right               | Seek video forward 5 seconds        | coursera.org          |
+| F or f                    | Exit full-screen mode               | coursera.org          |
 
 **Extra functionality:**
 

--- a/content-scripts/all_websites.ts
+++ b/content-scripts/all_websites.ts
@@ -1,6 +1,4 @@
-import {
-  keyboardEventToString,
-} from "../popup/src/common/keyboard_shortcuts";
+import { keyboardEventToString } from "../popup/src/common/keyboard_shortcuts";
 import { LiveProxyStorage, executeKeyboardEventListener } from "./utils";
 
 executeKeyboardEventListener(handleKeyDown);

--- a/content-scripts/coursera.ts
+++ b/content-scripts/coursera.ts
@@ -1,7 +1,10 @@
 import { keyboardEventToString } from "../popup/src/common/keyboard_shortcuts";
 import { LiveProxyStorage, executeKeyboardEventListener } from "./utils";
 
-executeKeyboardEventListener(handleKeyDown);
+// The handler here stops propagation and prevents default for all keydown events, that's why we delay adding its eventListener to allow other scripts to run first.
+setTimeout(() => {
+  executeKeyboardEventListener(handleKeyDown);
+});
 
 function handleKeyDown(e: KeyboardEvent, liveProxyStorage: LiveProxyStorage) {
   const video = document.querySelector("video");
@@ -11,59 +14,59 @@ function handleKeyDown(e: KeyboardEvent, liveProxyStorage: LiveProxyStorage) {
 
   const keyboardShortcuts = liveProxyStorage.keyboardShortcuts;
   const currentPress = keyboardEventToString(e);
+  e.stopImmediatePropagation();
+  e.preventDefault();
 
   // Functionality for both fullscreen and non-fullscreen modes as long as the focused element is the video or an ancestor of the video.
   if (
     document.activeElement == video ||
     document.activeElement?.querySelector("video")
   ) {
+    const inc = 5;
     switch (currentPress) {
       case keyboardShortcuts.subtitles:
         const textTracks = video.textTracks;
         if (!textTracks || textTracks.length === 0) {
           break;
         }
-
         const englishTrack = Array.from(textTracks).find(
           (e) => e.language === "en"
         );
         if (!englishTrack) {
           break;
         }
-
         if (englishTrack.mode === "showing") {
           englishTrack.mode = "disabled";
         } else {
           englishTrack.mode = "showing";
         }
-
-        e.preventDefault();
         break;
-    }
-  }
 
-  // Functionality for fullscreen mode only (as they are already working in non-fullscreen mode).
-  if (document.fullscreenElement) {
-    const inc = 5;
-    switch (currentPress) {
       case keyboardShortcuts.forward:
         video.currentTime += inc;
         break;
+
       case keyboardShortcuts.backward:
         video.currentTime -= inc;
         break;
+
       case keyboardShortcuts.playPause:
         if (video.paused) {
           video.play();
         } else {
           video.pause();
         }
-        e.preventDefault();
         break;
+
       case keyboardShortcuts.fullscreen:
-        // We are already in full screen mode, so exit it.
-        document.exitFullscreen();
-        e.preventDefault();
+        const fullscreenButton: HTMLElement | null = document.fullscreenElement
+          ? document.querySelector("button[aria-label='Exit full Screen']")
+          : document.querySelector("button[aria-label='Full Screen']");
+        if (fullscreenButton) {
+          fullscreenButton.click();
+        } else {
+          console.error("Could not find fullscreen button");
+        }
         break;
     }
   }

--- a/tests/integration.test.js
+++ b/tests/integration.test.js
@@ -131,28 +131,38 @@ describe("Video experience enhancer", function () {
       )
       .click();
 
+    console.log("Seeking forward.");
+    const video = await driver.findElement(By.css("video"));
+    let currentTime = Number(await video.getAttribute("currentTime"));
+    await driver.actions().sendKeys(Key.ARROW_RIGHT).perform();
+
+    console.log("Testing that the video is seeked forward.");
+    let newCurrentTime = Number(await video.getAttribute("currentTime"));
+    expect(newCurrentTime).to.be.closeTo(currentTime + 5, 5);
+    currentTime = newCurrentTime;
+
     console.log("Entering fullscreen mode.");
     const fullscreenButton = await driver
       .findElement(By.css('button[title="Fullscreen"]'))
       .click();
 
     console.log("Testing that the video is playing.");
-    const video = await driver.findElement(By.css("video"));
     expect(await video.getProperty("paused")).to.equal(false);
 
     console.log("Pausing the video.");
     await driver.actions().sendKeys(" ").perform();
 
     console.log("Testing that the video is paused.");
+    await video.click(); // Focus the element.
     expect(await video.getProperty("paused")).to.equal(true);
 
-    let currentTime = Number(await video.getAttribute("currentTime"));
+    currentTime = Number(await video.getAttribute("currentTime"));
 
     console.log("Seeking forward.");
     await driver.actions().sendKeys(Key.ARROW_RIGHT).perform();
 
     console.log("Testing that the video is seeked forward.");
-    let newCurrentTime = Number(await video.getAttribute("currentTime"));
+    newCurrentTime = Number(await video.getAttribute("currentTime"));
     expect(newCurrentTime).to.be.closeTo(currentTime + 5, 5);
     currentTime = newCurrentTime;
 
@@ -171,7 +181,6 @@ describe("Video experience enhancer", function () {
     expect(await video.getProperty("paused")).to.equal(false);
 
     console.log("Pressing 'c' to show the English subtitles.");
-    await video.click(); // Focus the element.
     await driver.actions().sendKeys("c").perform();
 
     console.log("Testing that the English subtitles are shown.");


### PR DESCRIPTION
# Pull Request

## Description

This PR adds support for non-screen mode as well (full-screen mode was already supported).

This is more important now since we allow the user editing keyboard shortcuts, which can make the extension shortcuts different from the default video player which would confuse the user if extension shortcuts is not applied on non-screen mode.  
For this to work, default video player behavior has been disabled to avoid conflict in actions and strange behaviors.

## Related Issue

None

## Checklist

- [x] I have tested the changes locally.
- [x] I have added necessary documentation or updated existing documentation.
- [x] I have followed the coding style and guidelines of this project.
- [x] I have added appropriate unit and/or integration tests (if applicable).

## Screenshots (if applicable)

N/A

## Additional Notes

None
